### PR TITLE
Add optional config to disable jest dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ const testConfig = require('./eslint/test');
 const typedConfig = require('./eslint/typed');
 const unicornConfig = require('./eslint/unicorn');
 
-module.exports = async options => [
+module.exports = async(options, { disableJest } = {}) => [
   await antfu.default(),
   generalConfig,
   unicornConfig,
   typedConfig,
-  testConfig,
+  ...(disableJest ? [] : [ testConfig ]),
   {
     files: [ '**/bin/*.ts' ],
     rules: {


### PR DESCRIPTION
This change adds an optional config object. Currently, it only allows you to disable the jest config, thereby removing the hard dependency the config has on jest.