### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Ruben Taelman <rubensworks@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/rubensworks/eslint-config#readme",
-  "repository": "git@github.com:rubensworks/eslint-config.git",
+  "repository": "git+https://github.com/rubensworks/eslint-config.git",
   "bugs": {
     "url": "https://github.com/rubensworks/eslint-config/issues"
   },


### PR DESCRIPTION
## Summary
- update repository metadata from the SSH GitHub shorthand to the public HTTPS Git URL
- leave package contents, version, homepage, bugs URL, license, and dependencies unchanged

## Validation
- `npm view @rubensworks/eslint-config@3.1.0 name version repository homepage bugs license --json`
- `node -e "const p=require('./package.json'); if (p.name !== '@rubensworks/eslint-config') throw new Error('wrong package'); if (p.repository !== 'git+https://github.com/rubensworks/eslint-config.git') throw new Error('repository metadata missing'); if (p.homepage !== 'https://github.com/rubensworks/eslint-config#readme') throw new Error('homepage changed'); if (p.bugs.url !== 'https://github.com/rubensworks/eslint-config/issues') throw new Error('bugs changed'); console.log('metadata ok')"`
- `npm pack --dry-run --ignore-scripts --json .`
- `npm test`
- `npm run build`
- `git diff --check`